### PR TITLE
修复挂掉的接口

### DIFF
--- a/api.py
+++ b/api.py
@@ -88,6 +88,8 @@ class NetEaseMusicAPI:
             "cover_url": result.get("cover"),
             "audio_url": result.get("music_url"),
         }
+    async def close(self):
+        await self.session.close()
 class NetEaseMusicAPINodeJs:
     """
     网易云音乐API NodeJs版本
@@ -96,7 +98,7 @@ class NetEaseMusicAPINodeJs:
         # http://netease_cloud_music_api:{port}/
         self.base_url = base_url
         self.session = aiohttp.ClientSession(base_url)
-        pass
+
     async def _request(self, url: str, data: dict = {}, method: str = "GET"):
         if method.upper() == "POST":
             async with self.session.post(url, data=data) as response:
@@ -148,11 +150,14 @@ class NetEaseMusicAPINodeJs:
         """
         获取额外信息
         """
-        url = "/song/url?id={song_id}"
-        result = await self._request(url)
+        url = "/song/url"
+        data = {"id": song_id}
+        result = await self._request(url, data=data, method="POST")
         return {
             "audio_url": result["data"][0].get("url", "")
         }
+    async def close(self):
+        await self.session.close()
 class MusicSearcher:
     """
     用于从指定音乐平台搜索歌曲信息的工具类。
@@ -226,5 +231,5 @@ class MusicSearcher:
         except Exception as e:
             logger.error(f"请求异常: {e}")
             return None
-
-
+    async def close(self):
+        await self.session.close()

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import random
 import aiofiles
 import aiohttp
+import traceback
 from astrbot.api.event import filter, AstrMessageEvent
 import astrbot.api.message_components as Comp
 from astrbot.api.star import Context, Star, register
@@ -131,6 +132,7 @@ class MusicPlugin(Star):
             except TimeoutError as _:
                 yield event.plain_result("点歌超时！")
             except Exception as e:
+                logger.error(traceback.format_exc())
                 logger.error("点歌发生错误" + str(e))
 
         event.stop_event()
@@ -303,3 +305,6 @@ class MusicPlugin(Star):
                         logger.error(f"歌曲下载失败，HTTP 状态码：{response.status}")
         except Exception as e:
             logger.error(f"歌曲下载失败，错误信息：{e}")
+    async def terminate(self):
+        '''可选择实现 terminate 函数，当插件被卸载/停用时会调用。'''
+        await self.api.close()

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_music # 这是你的插件的唯一识别名。
 desc: 点歌插件，支持按钮点歌、ai点歌、音乐卡片播放、语音播放、热评、歌词、歌单、多音源、无需VIP # 插件简短描述
 help:  # 插件的帮助信息
-version: v1.0.1 # 插件版本号。格式：v1.1.1 或者 v1.1
+version: v1.0.2 # 插件版本号。格式：v1.1.1 或者 v1.1
 author: Zhalslar # 作者
 repo: https://github.com/Zhalslar/astrbot_plugin_music # 插件的仓库地址


### PR DESCRIPTION
经排查，网易云nodejs 的extra data接口挂掉了。通过将请求方式换成post恢复。
报错更详细。
请求池优雅关闭。