### PR TITLE
fix(plugin): 修正查歌词渲染字体文件路径错误

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -124,7 +124,7 @@ class PluginConfig(ConfigNode):
         super().__init__(config)
         self.context = context
 
-        self.font_path = Path(get_astrbot_plugin_path()) / "fonts" / "simhei.ttf"
+        self.font_path = Path(get_astrbot_plugin_path()) / "astrbot_plugin_music" / "fonts" / "simhei.ttf"
         self.data_dir = StarTools.get_data_dir("astrbot_plugin_music")
         self.songs_dir = self.data_dir / "songs"
         self.songs_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
将字体文件路径从插件根目录下的fonts更改为该插件目录下的fonts，以解决字体加载失败问题

## Summary by Sourcery

错误修复：
- 修复了字体文件路径不正确的问题，该问题导致音乐插件歌词渲染字体加载失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect font file path that caused the music plugin lyrics rendering font to fail loading.

</details>