### PR TITLE
fix: 修复使用网易云平台点歌 + 发送语音时，歌词会变成歌词 API URL

### DIFF
--- a/core/platform/base.py
+++ b/core/platform/base.py
@@ -75,9 +75,6 @@ class BaseMusicPlayer(ABC):
                 song.audio_url = data.get("url")
             if not song.cover_url:
                 song.cover_url = data.get("pic")
-            # 不应该将获取到的 lrc url 赋值给 lyrics，因为 lyrics 需要具体的歌词文本
-            # if not song.lyrics:
-            #     song.lyrics = data.get("lrc")
         return song
 
     async def fetch_comments(self, song: Song) -> Song:

--- a/core/platform/base.py
+++ b/core/platform/base.py
@@ -75,8 +75,9 @@ class BaseMusicPlayer(ABC):
                 song.audio_url = data.get("url")
             if not song.cover_url:
                 song.cover_url = data.get("pic")
-            if not song.lyrics:
-                song.lyrics = data.get("lrc")
+            # 不应该将获取到的 lrc url 赋值给 lyrics，因为 lyrics 需要具体的歌词文本
+            # if not song.lyrics:
+            #     song.lyrics = data.get("lrc")
         return song
 
     async def fetch_comments(self, song: Song) -> Song:


### PR DESCRIPTION
主要问题出现在发送语音的代码中

https://github.com/Zhalslar/astrbot_plugin_music/blob/d4a2c4bb5167a30df42f1ea574d3f88956083b8d/core/sender.py#L130-L138

https://github.com/Zhalslar/astrbot_plugin_music/blob/d4a2c4bb5167a30df42f1ea574d3f88956083b8d/core/platform/base.py#L66-L80

在使用 TXQQ 音乐聚合平台时，`fetch_songs` 方法直接能够直接获取到所有基本信息，不会执行 `fetch_extra` 方法

https://github.com/Zhalslar/astrbot_plugin_music/blob/d4a2c4bb5167a30df42f1ea574d3f88956083b8d/core/platform/txqq.py#L129-L138

而在使用网易云平台时，`fetch_songs` 方法只会获取到基本信息，`audio_url` 为空，会执行 `fetch_extra` 方法，虽然获取到了正确的语音 URL，但是会把歌词 URL 赋值给歌曲的 lyrics 属性，导致歌词变成了 歌词 URL

https://github.com/Zhalslar/astrbot_plugin_music/blob/d4a2c4bb5167a30df42f1ea574d3f88956083b8d/core/platform/ncm.py#L41-L49

修改后，`fetch_extra` 方法不会检查歌词，而是在后续交给 `fetch_lyrics` 方法，获取正确的歌词

https://github.com/Zhalslar/astrbot_plugin_music/blob/d4a2c4bb5167a30df42f1ea574d3f88956083b8d/core/platform/base.py#L109-L128

## Summary by Sourcery

错误修复：
- 当使用在额外歌曲元数据中返回 LRC URL 的平台时，防止歌词被歌词 API 的 URL 覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent lyrics from being overwritten with the lyrics API URL when using platforms that return an LRC URL in extra song metadata.

</details>