### PR TITLE
fix: avoid false music command triggers

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,7 +59,11 @@ class MusicPlugin(Star):
             elif word:
                 word_ = word.strip().lower()
                 for keyword in player.platform.keywords:
-                    if keyword.lower() in word_:
+                    kw = keyword.lower()
+                    # Avoid treating normal sentences containing a platform keyword
+                    # (e.g. "主动加这个qq吗") as music commands.
+                    # Only exact platform commands or "<platform>点歌" should match.
+                    if word_ == kw or word_ == f"{kw}点歌":
                         return player
 
     def _register_player(self):


### PR DESCRIPTION
## Summary
- restrict platform keyword matching to exact command words or `<platform>点歌`
- prevent normal messages containing keywords like `qq` from triggering song search accidentally

## Example
Before this change, a wake/mention message such as:

```text
你能尝试一下怎么主动加这个qq吗
```

could be parsed as a QQ music command because `qq` was matched by substring.

After this change, only commands like `qq <song>` or `qq点歌 <song>` match.

## Test
- `python3 -m py_compile main.py`

## Summary by Sourcery

Bug Fixes:
- 将平台关键词匹配限制为仅匹配精确的命令词或“\<platform>点歌”，以防止普通文本被误识别为音乐指令并意外触发。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Restrict platform keyword matching to exact command words or '<platform>点歌' to prevent accidental music command triggers from regular text.

</details>