### PR TITLE
feat: add configurable local record source for NapCat

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ _🎵 高性能多平台点歌插件 🎵_
 
 > 排在前面的方式优先，发送失败将自动尝试下一种。
 
+**napcat_record_source**
+
+仅对 aiocqhttp（NapCat）的 `record` 语音模式生效，用于避免 AstrBot 将整段
+音频转码为 WAV 后再 Base64 编码进 WebSocket：
+
+- `base64`：兼容模式，保持 AstrBot 默认行为。
+- `url`：把音频 URL 原样交给 NapCat 下载。
+- `local_file`：插件先下载音频，再把绝对路径交给 NapCat。AstrBot 与 NapCat 必须
+  共享该插件缓存所在的 `/AstrBot/data` 挂载；否则 NapCat 无法访问该路径。
+
 ---
 
 ### 🧩 附加功能
@@ -192,4 +202,3 @@ _🎵 高性能多平台点歌插件 🎵_
 ## 📌 注意事项
 
 - 想第一时间得到反馈的可以来作者的插件反馈群（QQ群）：460973561（不点star不给进）
-

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -116,6 +116,17 @@
             "wecom"
         ]
     },
+    "napcat_record_source": {
+        "description": "NapCat 语音来源",
+        "hint": "仅 aiocqhttp（NapCat）的语音模式有效。base64 保持 AstrBot 默认的转码与编码行为；url 让 NapCat 直接下载音频；local_file 先下载到插件缓存，再将共享的绝对路径交给 NapCat。选择 local_file 前，请确认两个容器共享 /AstrBot/data。",
+        "type": "string",
+        "options": [
+            "base64",
+            "url",
+            "local_file"
+        ],
+        "default": "base64"
+    },
     "file_supported": {
         "description": "支持发文件的消息平台",
         "hint": "此配置定义哪些消息平台支持发送文件消息，不支持的平台发送歌曲时将不采用文件模式",

--- a/core/config.py
+++ b/core/config.py
@@ -114,6 +114,7 @@ class PluginConfig(ConfigNode):
     cards_per_row: int
     send_modes: list[str]
     record_supported: list[str]
+    napcat_record_source: str
     file_supported: list[str]
     enable_comments: bool
     enable_lyrics: bool
@@ -140,6 +141,11 @@ class PluginConfig(ConfigNode):
         self._send_modes = [m.split("(", 1)[0].strip() for m in self.send_modes]
 
     @property
+    def napcat_record_source(self) -> str:
+        """读取持久化的 NapCat 音频来源，缺失时保持历史兼容模式。"""
+        return self._data.get("napcat_record_source", "base64")
+
+    @property
     def http_proxy(self) -> str | None:
         return self.proxy or None
 
@@ -150,5 +156,4 @@ class PluginConfig(ConfigNode):
     @property
     def real_song_limit(self) -> int:
         return 1 if "single" in self.select_mode else self.song_limit
-
 

--- a/core/onebot_record.py
+++ b/core/onebot_record.py
@@ -1,0 +1,19 @@
+"""仅供 OneBot/NapCat 使用的原始语音消息段。"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class OneBotRecord:
+    """让 NapCat 直接读取 URL 或共享路径，避免 AstrBot 转为 Base64。
+
+    该类刻意不继承 AstrBot 的 ``Record``。aiocqhttp 适配器会对内置
+    ``Record`` 强制下载、转 WAV 并 Base64 编码；普通消息段则会直接使用
+    ``toDict`` 的结果。该对象只应在 aiocqhttp 事件中创建。
+    """
+
+    file: str
+
+    def toDict(self) -> dict[str, dict[str, str] | str]:
+        """返回 OneBot v11 的 record 段，保留原始来源。"""
+        return {"type": "record", "data": {"file": self.file}}

--- a/core/sender.py
+++ b/core/sender.py
@@ -16,6 +16,7 @@ from .config import PluginConfig
 from .downloader import Downloader
 from .lyrics_renderer import LyricsRenderer
 from .model import Song
+from .onebot_record import OneBotRecord
 from .platform import BaseMusicPlayer, TXQQMusic
 from .song_renderer import CardRenderer
 
@@ -219,7 +220,7 @@ class MusicSender:
     async def send_record(
         self, event: AstrMessageEvent, player: BaseMusicPlayer, song: Song
     ) -> bool:
-        """发语音"""
+        """发送语音，并按 NapCat 配置选择音频来源。"""
         if not song.audio_url:
             song = await player.fetch_extra(song)
         if not song.audio_url:
@@ -227,7 +228,24 @@ class MusicSender:
             return False
         try:
             logger.debug(f"正在发送【{song.name}】音频: {song.audio_url}")
-            seg = Record.fromURL(song.audio_url)
+            if isinstance(event, AiocqhttpMessageEvent):
+                source = self.cfg.napcat_record_source
+                if source == "url":
+                    seg = OneBotRecord(file=song.audio_url)
+                elif source == "local_file":
+                    file_path = await self.downloader.download_song(song.audio_url)
+                    if not file_path:
+                        logger.error(f"【{song.name}】NapCat 本地语音文件下载失败")
+                        return False
+                    seg = OneBotRecord(file=str(file_path.resolve()))
+                elif source == "base64":
+                    seg = Record.fromURL(song.audio_url)
+                else:
+                    raise ValueError(
+                        f"不支持的 NapCat 语音来源配置: {source!r}"
+                    )
+            else:
+                seg = Record.fromURL(song.audio_url)
             await event.send(event.chain_result([seg]))
             return True
         except Exception as e:

--- a/tests/test_napcat_record_source.py
+++ b/tests/test_napcat_record_source.py
@@ -1,0 +1,102 @@
+"""NapCat 原始语音来源的零依赖回归测试。"""
+
+import importlib.util
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+PLUGIN_ROOT = Path(__file__).parents[1]
+
+
+def load_onebot_record_module():
+    """不加载插件其余依赖，单独导入纯消息段定义。"""
+    path = PLUGIN_ROOT / "core" / "onebot_record.py"
+    spec = importlib.util.spec_from_file_location("onebot_record_for_test", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_config_module():
+    """用最小 AstrBot 桩导入配置模块，验证兼容默认值的读取逻辑。"""
+    astrbot = types.ModuleType("astrbot")
+    api = types.ModuleType("astrbot.api")
+    api.logger = types.SimpleNamespace(warning=lambda *_: None)
+    core = types.ModuleType("astrbot.core")
+    config_package = types.ModuleType("astrbot.core.config")
+    astrbot_config = types.ModuleType("astrbot.core.config.astrbot_config")
+    astrbot_config.AstrBotConfig = type("AstrBotConfig", (), {})
+    star = types.ModuleType("astrbot.core.star")
+    context = types.ModuleType("astrbot.core.star.context")
+    context.Context = type("Context", (), {})
+    utils = types.ModuleType("astrbot.core.utils")
+    astrbot_path = types.ModuleType("astrbot.core.utils.astrbot_path")
+    astrbot_path.get_astrbot_plugin_data_path = lambda: Path("/tmp")
+    astrbot_path.get_astrbot_plugin_path = lambda: Path("/tmp")
+
+    modules = {
+        "astrbot": astrbot,
+        "astrbot.api": api,
+        "astrbot.core": core,
+        "astrbot.core.config": config_package,
+        "astrbot.core.config.astrbot_config": astrbot_config,
+        "astrbot.core.star": star,
+        "astrbot.core.star.context": context,
+        "astrbot.core.utils": utils,
+        "astrbot.core.utils.astrbot_path": astrbot_path,
+    }
+    path = PLUGIN_ROOT / "core" / "config.py"
+    spec = importlib.util.spec_from_file_location("music_config_for_test", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    with patch.dict(sys.modules, modules):
+        spec.loader.exec_module(module)
+    return module
+
+
+class OneBotRecordTests(unittest.TestCase):
+    def test_preserves_url_as_onebot_record_file(self):
+        module = load_onebot_record_module()
+        record = module.OneBotRecord("https://example.com/song.mp3")
+
+        self.assertEqual(
+            record.toDict(),
+            {
+                "type": "record",
+                "data": {"file": "https://example.com/song.mp3"},
+            },
+        )
+
+    def test_preserves_shared_local_file_path(self):
+        module = load_onebot_record_module()
+        path = "/AstrBot/data/plugin_data/astrbot_plugin_music/songs/song.mp3"
+
+        self.assertEqual(module.OneBotRecord(path).toDict()["data"]["file"], path)
+
+
+class NapCatRecordConfigTests(unittest.TestCase):
+    def test_schema_declares_all_record_sources(self):
+        schema = json.loads((PLUGIN_ROOT / "_conf_schema.json").read_text())
+        setting = schema["napcat_record_source"]
+
+        self.assertEqual(setting["default"], "base64")
+        self.assertEqual(setting["options"], ["base64", "url", "local_file"])
+
+    def test_missing_persisted_setting_uses_compatible_default(self):
+        module = load_config_module()
+        config = object.__new__(module.PluginConfig)
+        object.__setattr__(config, "_data", {})
+
+        self.assertEqual(config.napcat_record_source, "base64")
+
+    def test_reads_persisted_record_source_instead_of_class_default(self):
+        module = load_config_module()
+        config = object.__new__(module.PluginConfig)
+        object.__setattr__(config, "_data", {"napcat_record_source": "local_file"})
+
+        self.assertEqual(config.napcat_record_source, "local_file")


### PR DESCRIPTION
Closes #67

## 变更

- 新增 `napcat_record_source` 配置：`base64`（默认）、`url`、`local_file`；
- 仅 aiocqhttp/NapCat 的语音模式使用该配置，其他平台保持内置 `Record` 行为；
- `local_file` 下载到插件缓存后，以 OneBot 原始 `record.file` 发送共享绝对路径，避开 WAV/Base64/WebSocket 的完整媒体传输链路；

<img width="1762" height="1240" alt="image" src="https://github.com/user-attachments/assets/fe02e050-e187-4032-82f8-ac8d7ca14c77" />


## 部署说明

`local_file` 要求 AstrBot 与 NapCat 可访问同一 `/AstrBot/data` 挂载路径。

## 测试

- `python3 -m unittest discover -s tests -v`
- `ruff check .`
- `python3 -m json.tool _conf_schema.json`

## Summary by Sourcery

为 NapCat 添加可配置的语音消息源选项，并将其集成到 aiocqhttp 录音发送中。

新特性：
- 引入可配置的 `napcat_record_source` 设置，用于控制 NapCat 获取语音音频的方式（Base64、直接 URL 或共享本地文件路径）。

增强：
- 将 aiocqhttp 的语音发送通过专用的 OneBot 录音段进行路由，以在配置时绕过 AstrBot 的 WAV/Base64 传输。
- 在 README 中记录新的 NapCat 录音源行为及其配置方式。

测试：
- 为 OneBot 录音段行为以及 NapCat 录音源配置的默认值和 schema 添加回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable NapCat voice message source options and integrate them into aiocqhttp record sending.

New Features:
- Introduce a configurable `napcat_record_source` setting to control how NapCat obtains voice audio (Base64, direct URL, or shared local file path).

Enhancements:
- Route aiocqhttp voice sending through a dedicated OneBot record segment to bypass AstrBot WAV/Base64 transfer when configured.
- Document the new NapCat record source behavior and configuration in the README.

Tests:
- Add regression tests for the OneBot record segment behavior and NapCat record source configuration defaults and schema.

</details>