### PR TITLE
feat: 在各平台间新增对点歌消息的追踪与撤回支持

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -127,9 +127,9 @@
         },
         "default": 30
     },
-    "timeout_recall": {
+    "recall_select": {
         "description": "撤回选歌消息",
-        "hint": "达到超时时长后，撤回之前发送的选歌消息 (仅 aiocqhttp 平台支持)",
+        "hint": "点歌成功后，撤回之前发送的选歌消息",
         "type": "bool",
         "default": true
     },

--- a/core/config.py
+++ b/core/config.py
@@ -16,16 +16,6 @@ from astrbot.core.utils.astrbot_path import (
 
 
 class ConfigNode:
-    """
-    配置节点, 把 dict 变成强类型对象。
-
-    规则：
-    - schema 来自子类类型注解
-    - 声明字段：读写，写回底层 dict
-    - 未声明字段和下划线字段：仅挂载属性，不写回
-    - 支持 ConfigNode 多层嵌套（lazy + cache）
-    """
-
     _SCHEMA_CACHE: dict[type, dict[str, type]] = {}
     _FIELDS_CACHE: dict[type, set[str]] = {}
 
@@ -58,7 +48,7 @@ class ConfigNode:
                 continue
             if self._is_optional(tp):
                 continue
-            logger.warning(f"[config:{self.__class__.__name__}] 缺少字段: {key}")
+            logger.warning(f"[config:{self.__class__.__name__}] miss key: {key}")
 
     def __getattr__(self, key: str) -> Any:
         if key in self._fields():
@@ -71,7 +61,7 @@ class ConfigNode:
                     if not isinstance(value, MutableMapping):
                         raise TypeError(
                             f"[config:{self.__class__.__name__}] "
-                            f"字段 {key} 期望 dict，实际是 {type(value).__name__}"
+                            f"key {key} need dict but {type(value).__name__}"
                         )
                     children[key] = tp(value)
                 return children[key]
@@ -90,18 +80,13 @@ class ConfigNode:
         object.__setattr__(self, key, value)
 
     def raw_data(self) -> Mapping[str, Any]:
-        """
-        底层配置 dict 的只读视图
-        """
         return MappingProxyType(self._data)
 
     def save_config(self) -> None:
-        """
-        保存配置到磁盘（仅允许在根节点调用）
-        """
+
         if not isinstance(self._data, AstrBotConfig):
             raise RuntimeError(
-                f"{self.__class__.__name__}.save_config() 只能在根配置节点上调用"
+                f"{self.__class__.__name__}.save_config() only support AstrBotConfig"
             )
         self._data.save_config()
 
@@ -119,7 +104,7 @@ class PluginConfig(ConfigNode):
     enable_lyrics: bool
     proxy: str
     timeout: int
-    timeout_recall: bool
+    recall_select: bool
     clear_cache: bool
     enc_sec_key: str
     enc_params: str

--- a/core/sender.py
+++ b/core/sender.py
@@ -2,14 +2,19 @@ import base64
 import random
 from io import BytesIO
 
+import botpy.message
+from botpy.http import Route
 from PIL import Image as PILImage
 
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
-from astrbot.core.message.components import File, Image, Record
+from astrbot.core.message.components import File, Image, Plain, Record
 from astrbot.core.message.message_event_result import MessageChain
 from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
     AiocqhttpMessageEvent,
+)
+from astrbot.core.platform.sources.qqofficial.qqofficial_message_event import (
+    QQOfficialMessageEvent,
 )
 
 from .config import PluginConfig
@@ -32,10 +37,10 @@ class MusicSender:
         self.lyrics_renderer = lyrics_renderer
         self.downloader = downloader
         self.song_renderer = song_renderer
+        self._selection_message_ids: dict[str, str | int] = {}
 
     @staticmethod
     def _format_time(duration_ms):
-        """格式化歌曲时长"""
         duration = duration_ms // 1000
 
         hours = duration // 3600
@@ -46,6 +51,57 @@ class MusicSender:
             return f"{hours}:{minutes:02d}:{seconds:02d}"
         else:
             return f"{minutes:02d}:{seconds:02d}"
+
+    async def _recall_qqofficial_message(
+        self, event: QQOfficialMessageEvent, message_id: str
+    ) -> None:
+        source = event.message_obj.raw_message
+        route_path = None
+        route_params = {}
+
+        if isinstance(source, botpy.message.GroupMessage):
+            route_path = "/v2/groups/{group_openid}/messages/{message_id}"
+            route_params["group_openid"] = source.group_openid
+        elif isinstance(source, botpy.message.C2CMessage):
+            route_path = "/v2/users/{openid}/messages/{message_id}"
+            route_params["openid"] = source.author.user_openid
+        elif isinstance(source, botpy.message.DirectMessage):
+            route_path = "/dms/{guild_id}/messages/{message_id}"
+            route_params["guild_id"] = source.guild_id
+        elif isinstance(source, botpy.message.Message):
+            await event.bot.api.recall_message(
+                channel_id=source.channel_id,
+                message_id=message_id,
+            )
+            return
+
+        if route_path:
+            await event.bot.api._http.request(
+                Route(
+                    "DELETE",
+                    route_path,
+                    message_id=message_id,
+                    **route_params,
+                )
+            )
+
+    @staticmethod
+    def _make_selection_key(event: AstrMessageEvent) -> str:
+        return f"{event.unified_msg_origin}:{event.get_sender_id()}"
+
+    async def _recall_selection_message(self, event: AstrMessageEvent) -> None:
+        key = self._make_selection_key(event)
+        message_id = self._selection_message_ids.pop(key, None)
+        if message_id is None:
+            return
+
+        try:
+            if isinstance(event, AiocqhttpMessageEvent):
+                await event.bot.delete_msg(message_id=int(message_id))
+            elif isinstance(event, QQOfficialMessageEvent):
+                await self._recall_qqofficial_message(event, str(message_id))
+        except Exception as e:
+            logger.warning(f"Failed to recall song selection message: {e}")
 
     @staticmethod
     async def send_msg(event: AiocqhttpMessageEvent, payloads: dict) -> int | None:
@@ -63,10 +119,8 @@ class MusicSender:
         songs: list[Song],
         title: str | None = None,
         player: BaseMusicPlayer | None = None,
-    ) -> int | None:
-        """
-        发送歌曲选择
-        """
+    ) -> str | int | None:
+        """发送歌曲选择"""
         if self.cfg.select_mode == "image":
             return await self._send_song_selection_image(
                 event=event, songs=songs, player=player
@@ -80,19 +134,36 @@ class MusicSender:
             formatted_songs.insert(0, title)
 
         msg = "\n".join(formatted_songs)
+        message_id: str | int | None = None
         if isinstance(event, AiocqhttpMessageEvent):
             payloads = {"message": [{"type": "text", "data": {"text": msg}}]}
-            return await self.send_msg(event, payloads)
+            message_id = await self.send_msg(event, payloads)
+        elif isinstance(event, QQOfficialMessageEvent):
+            platform = getattr(event.bot, "platform", None)
+            if platform is not None:
+                await platform.send_by_session(
+                    event.session,
+                    MessageChain(chain=[Plain(text=msg)]),
+                )
+                message_id = getattr(platform, "_session_last_message_id", {}).get(
+                    event.session_id
+                )
+            else:
+                await event.send(event.plain_result(msg))
+        else:
+            await event.send(event.plain_result(msg))
 
-        await event.send(event.plain_result(msg))
-        return None
+        if message_id is not None:
+            key = self._make_selection_key(event)
+            self._selection_message_ids[key] = message_id
+        return message_id
 
     async def _send_song_selection_image(
         self,
         event: AstrMessageEvent,
         songs: list[Song],
         player: BaseMusicPlayer | None = None,
-    ) -> int | None:
+    ) -> str | int | None:
         song_items = []
         cover_urls: list[str] = []
         for song in songs:
@@ -118,10 +189,28 @@ class MusicSender:
                     }
                 ]
             }
-            return await self.send_msg(event, payloads)
+            message_id = await self.send_msg(event, payloads)
+        elif isinstance(event, QQOfficialMessageEvent):
+            platform = getattr(event.bot, "platform", None)
+            if platform is not None:
+                await platform.send_by_session(
+                    event.session,
+                    MessageChain(chain=[Image.fromBytes(image_bytes)]),
+                )
+                message_id = getattr(platform, "_session_last_message_id", {}).get(
+                    event.session_id
+                )
+            else:
+                await event.send(MessageChain(chain=[Image.fromBytes(image_bytes)]))
+                message_id = None
+        else:
+            await event.send(MessageChain(chain=[Image.fromBytes(image_bytes)]))
+            message_id = None
 
-        await event.send(MessageChain(chain=[Image.fromBytes(image_bytes)]))
-        return None
+        if message_id is not None:
+            key = self._make_selection_key(event)
+            self._selection_message_ids[key] = message_id
+        return message_id
 
     async def _build_cover_map(
         self, cover_urls: list[str]
@@ -365,9 +454,13 @@ class MusicSender:
 
         if not sent:
             await event.send(event.plain_result("歌曲发送失败"))
+            return
 
-        if sent and self.cfg.enable_comments:
+        if self.cfg.recall_select:
+            await self._recall_selection_message(event)
+
+        if self.cfg.enable_comments:
             await self.send_comment(event, player, song)
 
-        if sent and self.cfg.enable_lyrics:
+        if self.cfg.enable_lyrics:
             await self.send_lyrics(event, player, song)

--- a/main.py
+++ b/main.py
@@ -27,7 +27,6 @@ class MusicPlugin(Star):
         self.keywords: list[str] = []
 
     async def initialize(self):
-        """插件加载时会调用"""
         self._register_player()
         self.downloader = Downloader(self.cfg)
         await self.downloader.initialize()
@@ -38,7 +37,6 @@ class MusicPlugin(Star):
         )
 
     async def terminate(self):
-        """当插件被卸载/停用时会调用"""
         await self.downloader.close()
         for parser in self.players:
             await parser.close()
@@ -110,11 +108,9 @@ class MusicPlugin(Star):
         # 未提输入序号，等待用户选择歌曲
         else:
             title = f"【{player.platform.display_name}】"
-            selection_message_id: int | None = None
 
             async def send_selection():
-                nonlocal selection_message_id
-                selection_message_id = await self.sender.send_song_selection(
+                await self.sender.send_song_selection(
                     event=event, songs=songs, title=title, player=player
                 )
 
@@ -143,8 +139,6 @@ class MusicPlugin(Star):
                 selected_song = songs[index - 1]
                 controller.stop()
                 await self.sender.send_song(event, player, selected_song, modes=modes)
-                if selection_message_id and self.cfg.timeout_recall:
-                    await event.bot.delete_msg(message_id=selection_message_id)  # type: ignore
 
             try:
                 await empty_mention_waiter(event)


### PR DESCRIPTION
## Summary by Sourcery

在各平台间新增对点歌消息的追踪与撤回支持，并使配置与这一新行为保持一致。

新特性：
- 支持通过 QQ 公众号平台事件发送点歌消息（文本和图片）。
- 按用户/会话追踪点歌消息的 ID，以便在歌曲被选中后进行撤回。

缺陷修复：
- 在有相关配置时，确保点歌消息会被撤回，而不是依赖单次调用的本地状态。

改进：
- 将点歌消息的撤回逻辑集中到发送端内部，并包含 QQ 公众号和 aiocqhttp 的平台特定删除实现。
- 简化与配置相关的日志输出，并将部分警告信息改为更清晰的英文措辞。
- 从核心和插件生命周期方法中移除冗余的文档字符串，使代码更简洁。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for tracking and recalling song selection messages across platforms and align configuration with the new behavior.

New Features:
- Support sending song selection messages (text and image) via QQ official platform events.
- Track song selection message IDs per user/session to allow later recall when a song is chosen.

Bug Fixes:
- Ensure song selection messages are recalled when configured, instead of relying on per-call local state.

Enhancements:
- Centralize selection message recall logic inside the sender, including platform-specific deletion for QQ official and aiocqhttp.
- Simplify configuration logging messages and convert some warnings to clearer English phrasing.
- Remove redundant docstrings from core and plugin lifecycle methods for leaner code.

</details>