### PR TITLE
Revert "update"

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -141,6 +141,12 @@
         "type": "bool",
         "default": true
     },
+    "clear_cache": {
+        "description": "重载插件时清空缓存",
+        "hint": "文件模式下需要下载音频文件，缓存目录在data/plugin_data/astrbot_plugin_music/songs，此选项用于重载插件时是否清空缓存",
+        "type": "bool",
+        "default": true
+    },
     "enc_sec_key": {
         "description": "网易云野生密钥",
         "hint": "",

--- a/core/config.py
+++ b/core/config.py
@@ -10,8 +10,8 @@ from astrbot.api import logger
 from astrbot.core.config.astrbot_config import AstrBotConfig
 from astrbot.core.star.context import Context
 from astrbot.core.utils.astrbot_path import (
+    get_astrbot_plugin_data_path,
     get_astrbot_plugin_path,
-    get_astrbot_temp_path,
 )
 
 
@@ -115,10 +115,12 @@ class PluginConfig(ConfigNode):
     def __init__(self, config: AstrBotConfig, context: Context):
         super().__init__(config)
         self.context = context
-        self.plugin_dir = Path(get_astrbot_plugin_path()) / self._plugin_name
-        self.font_path = self.plugin_dir / "fonts" / "simhei.ttf"
-        self.temp_dir = Path(get_astrbot_temp_path()) / self._plugin_name
-        self.songs_dir = self.temp_dir / "songs"
+
+        self.font_path = (
+            Path(get_astrbot_plugin_path()) / self._plugin_name / "fonts" / "simhei.ttf"
+        )
+        self.data_dir = Path(get_astrbot_plugin_data_path()) / self._plugin_name
+        self.songs_dir = self.data_dir / "songs"
         self.songs_dir.mkdir(parents=True, exist_ok=True)
 
         self._select_modes = [m.split("(", 1)[0].strip() for m in self.select_modes]

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -1,3 +1,4 @@
+import shutil
 import uuid
 from pathlib import Path
 
@@ -17,8 +18,20 @@ class Downloader:
         self.songs_dir = self.cfg.songs_dir
         self.session = aiohttp.ClientSession(proxy=self.cfg.http_proxy)
 
+
+    async def initialize(self):
+        if self.cfg.clear_cache:
+            self._ensure_cache_dir()
+
     async def close(self):
         await self.session.close()
+
+    def _ensure_cache_dir(self) -> None:
+        """重建缓存目录：存在则清空，不存在则新建"""
+        if self.songs_dir.exists():
+            shutil.rmtree(self.songs_dir)
+        self.songs_dir.mkdir(parents=True, exist_ok=True)
+        logger.debug(f"缓存目录已重建：{self.songs_dir}")
 
     async def download_image(self, url: str, close_ssl: bool = True) -> bytes | None:
         """下载图片"""
@@ -32,7 +45,6 @@ class Downloader:
 
     async def download_song(self, url: str) -> Path | None:
         """下载歌曲，返回保存路径"""
-        self.songs_dir.mkdir(parents=True, exist_ok=True)
         song_uuid = uuid.uuid4().hex
         file_path = self.songs_dir / f"{song_uuid}.mp3"
         try:

--- a/main.py
+++ b/main.py
@@ -38,6 +38,7 @@ class MusicPlugin(Star):
 
     async def initialize(self):
         self._register_player()
+        await self.downloader.initialize()
 
     async def terminate(self):
         await self.sender.close()
@@ -70,29 +71,6 @@ class MusicPlugin(Star):
             self.players.append(player)
             self.keywords.extend(player.platform.keywords)
         logger.debug(f"已注册触发词：{self.keywords}")
-
-    @filter.command(
-        "点歌",
-        alias={
-            "网易点歌",
-            "网易nj",
-            "QQ点歌",
-            "酷狗点歌",
-            "酷我点歌",
-            "百度点歌",
-            "咪咕点歌",
-            "荔枝点歌",
-            "蜻蜓点歌",
-            "喜马拉雅",
-            "5sing原创",
-            "5sing翻唱",
-            "全民K歌",
-        },
-    )
-    async def search_song(self, event: AstrMessageEvent):
-        """点歌、网易点歌、网易nj、QQ点歌、酷狗点歌、酷我点歌、百度点歌、咪咕点歌、荔枝点歌、蜻蜓点歌、喜马拉雅、5sing原创、5sing翻唱、全民K歌 <搜索词>"""
-        # 此函数仅用于注册显示命令
-        pass
 
     @filter.event_message_type(filter.EventMessageType.ALL)
     async def on_search_song(self, event: AstrMessageEvent):
@@ -213,26 +191,16 @@ class MusicPlugin(Star):
             return "歌词获取或发送失败"
 
     @filter.llm_tool()
-    async def play_song_by_name(
-        self, event: AstrMessageEvent, song_name: str, platform: str = ""
-    ):
-        """当用户想听歌时，根据歌名（可含歌手）搜索并播放音乐。
-
+    async def play_song_by_name(self, event: AstrMessageEvent, song_name: str):
+        """
+        当用户想听歌时，根据歌名（可含歌手）搜索并播放音乐。
         Args:
             song_name(string): 歌曲名称或包含歌手的关键词
-            platform(string): 点歌平台，默认可不填，使用默认播放器。可填写（严格匹配）：网易点歌、网易nj、QQ点歌、酷狗点歌、酷我点歌、百度点歌、咪咕点歌、荔枝点歌、蜻蜓点歌、喜马拉雅、5sing原创、5sing翻唱、全民K歌。
         """
-
-        player = (
-            self.get_player(name=platform)
-            if platform
-            else self.get_player(default=True)
-        )
+        player = self.get_player(default=True)
         if not player:
-            return f"无可用播放器：{platform}" if platform else "无可用播放器"
-        songs = await player.fetch_songs(
-            keyword=song_name, limit=1, extra=platform or None
-        )
+            return "无可用播放器"
+        songs = await player.fetch_songs(keyword=song_name, limit=1)
         if not songs:
             return "没找到相关歌曲"
         await self.sender.send_song(event, player, songs[0])

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,6 +2,6 @@ name: astrbot_plugin_music
 display_name: 点歌插件
 desc: 高性能低耦合的点歌插件, 支持AI点歌、卡片播放、语音播放、热评、歌词、歌单、多音源、无需VIP
 help: 略
-version: v2.1.7
+version: v2.1.6
 author: Zhalslar
 repo: https://github.com/Zhalslar/astrbot_plugin_music


### PR DESCRIPTION
Reverts Zhalslar/astrbot_plugin_music#81

## Summary by Sourcery

恢复最近更新之前的插件配置、缓存以及播放行为。

Enhancements:
- 将插件歌曲缓存恢复到持久化的插件数据目录，并在初始化时支持清理缓存。
- 简化 AI 歌曲播放逻辑，仅使用默认播放器，并移除显式的歌曲命令注册。

Chores:
- 将插件版本回退到 v2.1.6。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revert the recent update to restore the previous plugin configuration, caching, and playback behavior.

Enhancements:
- Restore plugin song caching to the persistent plugin data directory and support clearing the cache during initialization.
- Simplify AI song playback to use only the default player and remove the explicit song-command registration.

Chores:
- Revert the plugin version to v2.1.6.

</details>